### PR TITLE
Update link because page is dead

### DIFF
--- a/kermit_sdr/utils.py
+++ b/kermit_sdr/utils.py
@@ -123,7 +123,7 @@ class GpsResponse:
     """
     A read from a GPS GGA signal. Contains the following attributes:
 
-    Details from here: http://www.gpsinformation.org/dale/nmea.htm#GGA
+    Details from here: http://www.ae.utexas.edu/courses/ase389p7/projects/svatek/commands/GGA.html
 
     @var timestamp - the timestamp associated with the read
     @var lat - latitude


### PR DESCRIPTION
The link in this comment is dead. Replace with this link to the GPS page at UT Austin (likely to stay up for a while): http://www.ae.utexas.edu/courses/ase389p7/projects/svatek/commands/GGA.html